### PR TITLE
Updated CONFIGDIR definition for POSIX compliance. Fixes #3

### DIFF
--- a/gashell.sh
+++ b/gashell.sh
@@ -6,7 +6,7 @@
 
 #Path Vars
 REQBINS=("sed" "oathtool" "openssl" "zbarimg" "curl");
-CONFIGDIR="/home/$USER/.config/gashell";
+CONFIGDIR="$HOME/.config/gashell";
 SALTFILE="$CONFIGDIR/salt";
 SALTLENGTH=1024;
 CODESFILE="$CONFIGDIR/secrets"


### PR DESCRIPTION
CONFIGDIR was previously set to assume the home directory was
/home/$USER. However, when creating a user, the home directory is
permitted to be arbitrary. POSIX guarantees the existence of an
environment variable $HOME in all cases which points to the home
directory of the current user. Hence I updated CONFIGDIR to use
$HOME rather than /home/$USER.