### PR TITLE
More flexible `sed` strings

### DIFF
--- a/gashell.sh
+++ b/gashell.sh
@@ -332,8 +332,8 @@ if [ $# -gt 0 ]; then
 		fi
 
 		#Get secret and name from zbar
-		AUTHCODE=$(zbarimg -q --raw $QRLOC | sed "s/.*secret=//" | sed "s/&issuer=.*//");
-		AUTHCODE_NAME=$(zbarimg -q --raw $QRLOC | sed "s/.*&issuer=//");
+		AUTHCODE=$(zbarimg -q --raw $QRLOC | sed 's/.*secret=\([^&]*\).*/\1/');
+		AUTHCODE_NAME=$(zbarimg -q --raw $QRLOC | sed 's/otpauth:\/\/totp\/\([^?]*\)?.*/\1/; s/%20/_/g');
 
 		#If file exists, remove it
 		if [ -f $QRWEBOUTPUT ]; then


### PR DESCRIPTION
Hello!
I recently tried to use `GAShell` with PyPI's two-factor auth QR codes, and found that it wouldn't be able to add the codes by reading the QR code. I traced down the reason to issues with the way the `zbarimg` output was being parsed. With this pull request I intend to contribute a change that improves the parsing of the `zbarimg` output. Adding the PyPI QR code now works, and I tested that it still works with other QR codes I have access to.

Commit description:
> Replace `sed` patterns to enhance flexibility, so that the script works for QRs that present the attributes in different order than what the previous patterns assumed. Also, replace `%20` (the URL-encoded representation of a space) with underscores (spaces would be much harder to deal with) to improve the readability of the code list.